### PR TITLE
Servlet test pour la DB à supprimer plus tard

### DIFF
--- a/src/main/java/org/encheres/dal/DBtest.java
+++ b/src/main/java/org/encheres/dal/DBtest.java
@@ -1,0 +1,39 @@
+package org.encheres.dal;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet("/DBtest")
+public class DBtest extends HttpServlet {
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        response.setContentType("text/html");
+        PrintWriter out = response.getWriter();
+        
+        try (Connection connection = ConnectionProvider.getConnection()) {
+            DatabaseMetaData metaData = connection.getMetaData();
+            ResultSet rs = metaData.getTables(null, null, "%", new String[] { "TABLE" });
+            
+            out.println("<h1>Liste des tables</h1>");
+            while (rs.next()) {
+                out.println("<p>" + rs.getString("TABLE_NAME") + "</p>");
+            }
+        } catch (SQLException e) {
+            out.println("Erreur de connection à la DB " + e.getMessage());
+        }
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        doGet(request, response);
+    }
+}


### PR DESCRIPTION
Simple servlet de test qui devrait afficher les tables de la DB ENCHERES pour vérifier que tout fonctionne.

Vous pouvez la lancer comme on voyait dans les vid, mais si vous avez un server qui tourne:

On y accède comme ça: http://web_host/context/DBtest
- **web_host** j'imagine que pour tomcat local c'est 127.0.0.1:8080
- **context** doit être projetEncheres pour vous
